### PR TITLE
feat: Add Syzygy Synapse deployment artifacts

### DIFF
--- a/deploy-synapse.sh
+++ b/deploy-synapse.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# deploy-synapse.sh - Syzygy Synapse Unified Deployment
+
+set -euo pipefail
+
+echo "=== Syzygy Synapse Deployment ==="
+NAMESPACE="synapse-system"
+COCKROACHDB_HOST="cockroachdb-public.syzygy.svc.cluster.local" # Adjust if necessary
+
+# Prerequisites check
+command -v kubectl >/dev/null || { echo "ERROR: kubectl required"; exit 1; }
+command -v helm >/dev/null || { echo "ERROR: helm required"; exit 1; }
+
+# Create namespace
+kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+
+# Add Helm Repositories
+helm repo add temporalio https://helm.temporal.io
+helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+helm repo add milvus https://milvus-io.github.io/milvus-helm/
+helm repo add neo4j https://helm.neo4j.com/neo4j
+helm repo update
+
+# 1. Deploy Temporal (Cortex - Durable Execution)
+echo "[1/6] Deploying Temporal Cluster..."
+
+# NOTE: This configuration assumes CockroachDB is already deployed and accessible.
+# Ensure the 'temporal_synapse' database exists in CockroachDB.
+helm upgrade --install temporal temporalio/temporal \
+  --namespace $NAMESPACE \
+  --set server.replicaCount=3 \
+  --set cassandra.enabled=false \
+  --set postgresql.enabled=false \
+  --set mysql.enabled=false \
+  --set elasticsearch.enabled=false \
+  --set prometheus.enabled=true \
+  --set grafana.enabled=true \
+  --set externalSQL.enabled=true \
+  --set externalSQL.dialect=cockroachdb \
+  --set externalSQL.connection.host=$COCKROACHDB_HOST \
+  --set externalSQL.connection.port=26257 \
+  --set externalSQL.connection.database="temporal_synapse"
+  # CRITICAL: Add --set flags for user/password/tls configuration via secrets as required by your DB.
+
+# 2. Deploy NATS JetStream (Event Bus)
+echo "[2/6] Deploying NATS JetStream..."
+helm upgrade --install nats nats/nats \
+  --namespace $NAMESPACE \
+  --set cluster.replicas=3 \
+  --set nats.jetstream.enabled=true \
+  --set nats.jetstream.memStorage.enabled=false \
+  --set nats.jetstream.fileStorage.enabled=true \
+  --set nats.jetstream.fileStorage.size=10Gi
+
+# 3. Deploy Milvus (Memory Core - Vector DB)
+echo "[3/6] Deploying Milvus Cluster..."
+# Note: The service endpoint for clients will be 'milvus-proxy'
+helm upgrade --install milvus milvus/milvus \
+  --namespace $NAMESPACE \
+  --set cluster.enabled=true \
+  --set persistence.enabled=true
+
+# 4. Deploy Neo4j (Memory Core - Graph DB)
+echo "[4/6] Deploying Neo4j..."
+# CRITICAL: Set a strong, secure password for production use.
+NEO4J_PASSWORD="CHANGE_THIS_SECURE_PASSWORD"
+helm upgrade --install neo4j neo4j/neo4j \
+  --namespace $NAMESPACE \
+  --set neo4j.password=$NEO4J_PASSWORD
+
+# 5. Deploy Application Services
+echo "[5/6] Deploying Application Services..."
+# Assuming the manifests are saved in the k8s/ directory
+if [ -f "k8s/monday-sync-deployment.yaml" ] && [ -f "k8s/intel-harvester-cronjob.yaml" ]; then
+    kubectl apply -f k8s/monday-sync-deployment.yaml
+    kubectl apply -f k8s/intel-harvester-cronjob.yaml
+else
+    echo "ERROR: Kubernetes manifests not found in k8s/ directory."
+    exit 1
+fi
+
+echo "✓ Deployment sequence initiated."
+echo "Monitor rollout: kubectl get pods -n $NAMESPACE -w"
+echo "Neo4j Password (if default used): $NEO4J_PASSWORD"

--- a/docs/citations/MASTER_INDEX.md
+++ b/docs/citations/MASTER_INDEX.md
@@ -1,0 +1,1 @@
+# Syzygy Citation Master Index

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,9 @@
+# Kubernetes Manifests
+
+This directory contains the Kubernetes manifests for the Syzygy Synapse application services.
+
+## Prerequisites
+
+Before applying these manifests or running the `deploy-synapse.sh` script, you **must** build the container images for the `monday-sync` and `intel-harvester` services and push them to your container registry.
+
+The placeholder image names in the manifest files (`your-registry/monday-sync:latest` and `your-registry/intel-harvester:latest`) must be updated to point to the images you have built and pushed. Failure to do so will result in the deployment failing.

--- a/k8s/intel-harvester-cronjob.yaml
+++ b/k8s/intel-harvester-cronjob.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: intel-harvester
+  namespace: synapse-system
+spec:
+  schedule: "0 */6 * * *"  # Run every 6 hours
+  concurrencyPolicy: Forbid # Prevent overlapping runs
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          # CRITICAL: Update this image path to your registry
+          - name: harvester
+            image: your-registry/intel-harvester:latest
+            env:
+            # Infrastructure Endpoints
+            # Use the Milvus proxy service name for cluster mode access
+            - name: MILVUS_HOST
+              value: "milvus-proxy.synapse-system.svc.cluster.local"
+            - name: MILVUS_PORT
+              value: "19530"
+            - name: NEO4J_URI
+              value: "bolt://neo4j.synapse-system.svc.cluster.local:7687"
+            - name: NATS_URL
+              value: "nats://nats.synapse-system.svc.cluster.local:4222"
+            # Secrets Configuration
+            - name: AI_API_KEY # API key for embedding models (OpenAI, Google, etc.)
+              valueFrom:
+                secretKeyRef:
+                  name: synapse-ai-creds
+                  key: api-key
+          restartPolicy: OnFailure

--- a/k8s/monday-sync-deployment.yaml
+++ b/k8s/monday-sync-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monday-sync
+  namespace: synapse-system
+spec:
+  replicas: 2 # High availability
+  selector:
+    matchLabels:
+      app: monday-sync
+  template:
+    metadata:
+      labels:
+        app: monday-sync
+    spec:
+      containers:
+      # CRITICAL: Update this image path to your registry
+      - name: monday-sync
+        image: your-registry/monday-sync:latest
+        env:
+        # Secrets Configuration (configured in Step 4)
+        - name: MONDAY_TOKEN
+          valueFrom: { secretKeyRef: { name: monday-creds, key: token } }
+        - name: GITHUB_TOKEN
+          valueFrom: { secretKeyRef: { name: github-creds, key: token } }
+        # Infrastructure Endpoints (Service Discovery within the cluster)
+        - name: TEMPORAL_ADDRESS
+          value: "temporal-frontend.synapse-system.svc.cluster.local:7233"
+        - name: NATS_URL
+          value: "nats://nats.synapse-system.svc.cluster.local:4222"
+        # Assumes CockroachDB is deployed in the 'syzygy' namespace
+        - name: DB_HOST
+          value: "cockroachdb-public.syzygy.svc.cluster.local:26257"
+        ports:
+        - containerPort: 8080 # Port for webhooks/health checks
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monday-sync
+  namespace: synapse-system
+spec:
+  selector:
+    app: monday-sync
+  ports:
+  - port: 8080
+    targetPort: 8080

--- a/scripts/pre-commit-hook.sh
+++ b/scripts/pre-commit-hook.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# To install this hook, run the following command from the root of the repository:
+# cp scripts/pre-commit-hook.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+
+# .git/hooks/pre-commit (Syzygy Citation Tracker)
+
+CITATIONS_FILE="docs/citations/citations.jsonl"
+mkdir -p docs/citations
+
+# Extract URLs, DOIs, arXiv IDs from staged changes
+# We use git diff --cached to look at the content being committed.
+STAGED_CONTENT=$(git diff --cached)
+# Get the HEAD SHA if available, otherwise mark as initial
+COMMIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "initial")
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Function to log citations
+log_citation() {
+  local type=$1
+  local ref=$2
+  # Escape quotes in the reference for JSON compatibility
+  local escaped_ref=$(echo "$ref" | sed 's/"/\\"/g')
+  echo "{\"ts\":\"$TIMESTAMP\",\"commit\":\"$COMMIT_SHA\",\"type\":\"$type\",\"ref\":\"$escaped_ref\"}" >> "$CITATIONS_FILE"
+}
+
+# Extract URLs
+echo "$STAGED_CONTENT" | grep -Eoh '\bhttps?://[^\s<>"]+' | sort -u | while read url; do
+  log_citation "url" "$url"
+done
+
+# Extract DOIs
+echo "$STAGED_CONTENT" | grep -Eoh '\b10\.\d{4,9}/[-._;()/:A-Za-z0-9]+' | sort -u | while read doi; do
+  log_citation "doi" "$doi"
+done
+
+# Extract arXiv IDs
+echo "$STAGED_CONTENT" | grep -Eoh 'arXiv:[0-9]{4}\.[0-9]{4,5}' | sort -u | while read arxiv; do
+  log_citation "arxiv" "$arxiv"
+done
+
+# Deduplicate, sort, and stage the updated citations file
+if [[ -f "$CITATIONS_FILE" ]]; then
+  # Use a temporary file for sorting to ensure atomic update and avoid duplicates
+  TMP_FILE=$(mktemp)
+  sort -u "$CITATIONS_FILE" > "$TMP_FILE"
+  mv "$TMP_FILE" "$CITATIONS_FILE"
+  git add "$CITATIONS_FILE"
+fi


### PR DESCRIPTION
This commit introduces the initial set of deployment artifacts for the Syzygy Synapse architecture. It includes:

- Kubernetes manifests for the `monday-sync` and `intel-harvester` services, located in the `k8s/` directory.
- A comprehensive deployment script, `deploy-synapse.sh`, that uses Helm to deploy the core infrastructure components (Temporal, NATS, Milvus, Neo4j) and the application services.
- A citation tracking system, including a pre-commit hook to automatically record citations from committed code into `docs/citations/citations.jsonl`.
- A `README.md` file within the `k8s/` directory to provide instructions on building and pushing the required container images before deployment.