### PR TITLE
feat: Scaffold the SELF (Self-Evolving Lineage Framework)

### DIFF
--- a/memory/SELF_CYCLE_001.json
+++ b/memory/SELF_CYCLE_001.json
@@ -1,0 +1,19 @@
+{
+  "id": "SELF_CYCLE_001",
+  "context": {
+    "failure_trace": {
+      "test": "tests/test_cli.py::test_cli_run_command_with_real_config",
+      "error": "Simulated 'ValueError: I/O operation on closed file'",
+      "timestamp": "2025-10-01T06:01:42.159637"
+    }
+  },
+  "result": {
+    "patch": "# PATCH (Goal: Fix for Simulated 'ValueError: I/O operation on closed file')\n# Original code hash: -8865796686440865201\nimport logging\nfrom click.testing import CliRunner\nfrom optimizer.cli.main import cli\n\n\ndef test_cli_run_command():\n    runner = CliRunner()\n    result = runner.invoke(cli, [\"run\", \"--config-path\", \"nonexistent.yml\"])\n    assert result.exit_code != 0\n    assert \"Error: Configuration file not found at 'nonexistent.yml'\" in result.output\n\n\ndef test_cli_run_command_with_real_config():\n    # Reset logging to a clean state to prevent test pollution from other tests\n    # that might have configured file-based logging.\n    root_logger = logging.getLogger()\n    for handler in root_logger.handlers[:]:\n        root_logger.removeHandler(handler)\n        handler.close()\n\n    runner = CliRunner()\n    # Create a dummy config file for the test\n    with runner.isolated_filesystem():\n        with open(\"config.yml\", \"w\") as f:\n            f.write(\n                \"\"\"\nsimulation:\n  engine: \"pybullet\"\n  gravity: -9.8\n  time_step: 0.01\n\napi:\n  host: \"0.0.0.0\"\n  port: 8000\n\nlogging:\n  level: \"INFO\"\n  format: \"%(asctime)s - %(name)s - %(levelname)s - %(message)s\"\n  file: \"optimizer.log\"\n\"\"\"\n            )\n        result = runner.invoke(cli, [\"run\"])\n        assert result.exit_code == 0\n        assert \"Simulation complete.\" in result.output\n"
+  },
+  "benchmark": {
+    "clarity": 7.52,
+    "slop_index": 0.0,
+    "token_cost": 1356
+  },
+  "timestamp": "2025-10-01T06:01:42.160087"
+}

--- a/scripts/failure_tracer.py
+++ b/scripts/failure_tracer.py
@@ -1,0 +1,19 @@
+import json
+import datetime
+
+class FailureTracer:
+    """
+    Traces and records test failures to a structured format.
+    This is a placeholder for a more sophisticated error analysis engine.
+    """
+    def trace(self, test_name, error_message):
+        """Records a failure event."""
+        trace_data = {
+            "test": test_name,
+            "error": error_message,
+            "timestamp": datetime.datetime.now().isoformat(),
+        }
+        # In a real implementation, this would write to a dedicated log file
+        # or a database. For now, we'll just print it.
+        print(f"FAILURE TRACE: {json.dumps(trace_data, indent=2)}")
+        return trace_data

--- a/scripts/jules_memory_anchor.py
+++ b/scripts/jules_memory_anchor.py
@@ -1,0 +1,31 @@
+import json
+import datetime
+import os
+
+class JulesMemoryAnchor:
+    """
+    Anchors the results of a recovery or rewrite cycle into a persistent
+    memory format (JSON files in the memory/ directory).
+    """
+    def __init__(self, memory_dir="memory"):
+        self.memory_dir = memory_dir
+        os.makedirs(self.memory_dir, exist_ok=True)
+
+    def store(self, directive_id, context, result, benchmark):
+        """
+        Stores a memory node as a JSON file.
+        """
+        memory_node = {
+            "id": directive_id,
+            "context": context,
+            "result": result,
+            "benchmark": benchmark,
+            "timestamp": datetime.datetime.now().isoformat(),
+        }
+
+        file_path = os.path.join(self.memory_dir, f"{directive_id}.json")
+        with open(file_path, "w") as f:
+            json.dump(memory_node, f, indent=2)
+
+        print(f"MEMORY ANCHOR: Stored memory node to {file_path}")
+        return file_path

--- a/scripts/jules_recursive_loop_engine.py
+++ b/scripts/jules_recursive_loop_engine.py
@@ -1,0 +1,75 @@
+from scripts.failure_tracer import FailureTracer
+from scripts.patch_benchmark_matrix import PatchBenchmarkMatrix
+from scripts.jules_memory_anchor import JulesMemoryAnchor
+from scripts.jules_self_rewriter import JulesSelfRewriter
+
+class JulesRecursiveLoopEngine:
+    """
+    Orchestrates the recursive, self-evolving loop of the Jules agent.
+    This engine integrates failure tracing, patch generation, benchmarking,
+    and memory anchoring to enable the system to learn from its actions.
+    """
+    def __init__(self):
+        self.tracer = FailureTracer()
+        self.benchmark = PatchBenchmarkMatrix()
+        self.memory_anchor = JulesMemoryAnchor()
+        self.rewriter = JulesSelfRewriter()
+        print("JulesRecursiveLoopEngine initialized.")
+
+    def run_single_cycle(self, directive):
+        """
+        Runs a single, full cycle of the SELF framework.
+
+        This is a placeholder for a much more complex process that would
+        involve dynamic agent selection, context loading, and automated
+        recovery from real failures.
+        """
+        print(f"\n--- RUNNING SELF CYCLE FOR DIRECTIVE: {directive['id']} ---")
+
+        # 1. Execute a task (simulated)
+        # In a real scenario, this would execute a test or a task.
+        # We'll simulate a failure for demonstration purposes.
+        print("Step 1: Executing task (simulating a failure)...")
+        test_name = directive.get("test_name", "test_placeholder")
+        error_message = "Simulated 'ValueError: I/O operation on closed file'"
+
+        # 2. Trace the failure
+        print("Step 2: Tracing failure...")
+        failure_trace = self.tracer.trace(test_name, error_message)
+
+        # 3. Generate a patch (simulated)
+        print("Step 3: Generating recovery patch...")
+        context = {"failure_trace": failure_trace}
+        # The rewriter generates a "patch" for a target module
+        target_module = directive.get("target_module", "scripts/jules_self_rewriter.py")
+        patch = self.rewriter.rewrite(target_module, goal=f"Fix for {error_message}")
+
+        # 4. Benchmark the patch
+        print("Step 4: Benchmarking patch...")
+        score = self.benchmark.score(patch)
+        print(f"Benchmark score: {score}")
+
+        # 5. Anchor the cycle in memory
+        print("Step 5: Anchoring memory...")
+        self.memory_anchor.store(
+            directive_id=directive["id"],
+            context=context,
+            result={"patch": patch},
+            benchmark=score
+        )
+
+        print(f"--- SELF CYCLE FOR {directive['id']} COMPLETE ---")
+
+if __name__ == '__main__':
+    # Example of how to run a cycle
+    engine = JulesRecursiveLoopEngine()
+
+    # This directive would typically come from a dynamic generator or a task queue.
+    example_directive = {
+        "id": "SELF_CYCLE_001",
+        "goal": "Resolve the persistent I/O error in the CLI test.",
+        "test_name": "tests/test_cli.py::test_cli_run_command_with_real_config",
+        "target_module": "tests/test_cli.py"
+    }
+
+    engine.run_single_cycle(example_directive)

--- a/scripts/jules_self_rewriter.py
+++ b/scripts/jules_self_rewriter.py
@@ -1,0 +1,32 @@
+class JulesSelfRewriter:
+    """
+    A placeholder for the self-rewriting agent. In a real implementation,
+    this module would use an AI model to generate patches for its own
+    source code to improve its functionality over time.
+    """
+    def rewrite(self, module_path, goal):
+        """
+        Reads its own source code, generates a patch, and applies it.
+        """
+        print(f"SELF REWRITE: Attempting to rewrite {module_path} with goal: {goal}")
+        try:
+            with open(module_path, "r") as f:
+                source_code = f.read()
+
+            patch = self._generate_patch(source_code, goal)
+
+            # In a real system, you would apply the patch.
+            # For this scaffold, we'll just print it.
+            print(f"SELF REWRITE: Generated patch for {module_path}:\n{patch}")
+            return patch
+        except FileNotFoundError:
+            print(f"SELF REWRITE: Error - could not find module at {module_path}")
+            return None
+
+    def _generate_patch(self, source_code, goal):
+        """
+        Placeholder for a sophisticated AI-driven patch generation process.
+        """
+        # This is where the agent would call an LLM with the source code
+        # and a directive to generate an improved version.
+        return f"# PATCH (Goal: {goal})\n# Original code hash: {hash(source_code)}\n{source_code}"

--- a/scripts/patch_benchmark_matrix.py
+++ b/scripts/patch_benchmark_matrix.py
@@ -1,0 +1,22 @@
+class PatchBenchmarkMatrix:
+    """
+    Scores the quality of a generated patch based on a matrix of metrics.
+    This is a placeholder for a more advanced code quality analysis model.
+    """
+    def score(self, patch_code):
+        """
+        Scores the patch based on clarity, slop, and token cost.
+        """
+        if not patch_code:
+            return {"clarity": 0, "slop_index": 10, "token_cost": 0}
+
+        tokens = patch_code.split()
+        clarity = len(set(tokens)) / len(tokens) if tokens else 0
+        slop = patch_code.lower().count("try:") + patch_code.lower().count("except:")
+        token_cost = len(patch_code.encode("utf-8"))
+
+        return {
+            "clarity": round(clarity * 10, 2),
+            "slop_index": round(slop / 10, 2),
+            "token_cost": token_cost,
+        }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import logging
 from click.testing import CliRunner
 from optimizer.cli.main import cli
 
@@ -10,6 +11,13 @@ def test_cli_run_command():
 
 
 def test_cli_run_command_with_real_config():
+    # Reset logging to a clean state to prevent test pollution from other tests
+    # that might have configured file-based logging.
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        handler.close()
+
     runner = CliRunner()
     # Create a dummy config file for the test
     with runner.isolated_filesystem():


### PR DESCRIPTION
This commit introduces the foundational scaffolding for the SELF (Self-Evolving Lineage Framework), a recursive, self-rewriting agentic system designed to enable autonomous code evolution.

The core of this change is the creation of a set of interconnected Python modules that represent a single, executable cycle of the SELF loop:
- `jules_recursive_loop_engine.py`: The main orchestrator that runs the debug, patch, benchmark, and memory anchoring cycle.
- `failure_tracer.py`: A placeholder for a sophisticated failure analysis component.
- `patch_benchmark_matrix.py`: A module to score the quality of generated code patches.
- `jules_memory_anchor.py`: A component to store the context, outcome, and benchmark of each cycle into a persistent JSON-based memory in the `memory/` directory.
- `jules_self_rewriter.py`: A placeholder for the agent's ability to modify its own source code.

To support this framework, the necessary directory structure (`memory/`, `benchmarks/`, `backups/`, etc.) has been created at the root of the repository.

A runnable example within `jules_recursive_loop_engine.py` demonstrates a full, simulated cycle, confirming that the scaffolded components are correctly integrated.

This commit also resolves a persistent and complex `ValueError` in the `tests/test_cli.py` test. The root cause was identified as test pollution, where the global state of the Python `logging` module was being modified by previously run tests. The fix ensures test isolation by programmatically resetting the root logger's handlers before the test is executed.